### PR TITLE
update gradle configuration

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,6 +33,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }
   


### PR DESCRIPTION
Remove warning: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
